### PR TITLE
Use account information when creating new submission

### DIFF
--- a/code/FormGenerator.class.php
+++ b/code/FormGenerator.class.php
@@ -456,7 +456,7 @@ END;
         if (!isset($_SESSION[$namespace]) || empty($_SESSION[$namespace])) {
             $newly_created = true;
             $_SESSION[$namespace] = array();
-            $submission_id = Submissions::createBlankSubmission($form_id, $view_id, false);
+            $submission_id = Submissions::createBlankSubmission($form_id, $view_id, false, Core::$user->getAccountPlaceholders());
 
             $_SESSION[$namespace]["form_tools_form_id"]         = $form_id;
             $_SESSION[$namespace]["form_tools_view_id"]         = $view_id;


### PR DESCRIPTION
Form Builder forms do not use logged user account information when calling Submissions::createBlankSubmission.
This minor modification allow the use of placeholders like {$ACCOUNT_ID}, {$FIRST_NAME} etc for setting default values for fields in a Form Builder form.