### PR TITLE
Update function.page.php

### DIFF
--- a/smarty_plugins/function.page.php
+++ b/smarty_plugins/function.page.php
@@ -109,7 +109,7 @@ function smarty_function_page($params, &$smarty)
     $smarty->right_delimiter = '}}';
 
     $smarty->assign("eval_str", $template_info["content"]);
-    $smarty->assign("page_name", $template_vars["nav_pages"][$current_page - 1]["page_name"]);
+    $smarty->assign("page_name", $template_vars["nav_pages"][(int)$current_page - 1]["page_name"]);
     $smarty->assign("page_type", $page_type);
 
     // used in the form action attribute. This'll cause nice "/" paths for index.php to get redirected to index.php on


### PR DESCRIPTION
In PHP 8, line 112 may produce a Type Error:
"Fatal error: Uncaught TypeError: Unsupported operand types: string - int" [see https://stackoverflow.com/questions/66238017/fatal-error-uncaught-typeerror-unsupported-operand-types-string-int-in]

To prevent this error, $current_page should be cast to int before the subtraction operation is done.