### PR TITLE
Fixed simple typo in template_types smarty plugin

### DIFF
--- a/smarty_plugins/function.template_types.php
+++ b/smarty_plugins/function.template_types.php
@@ -28,7 +28,7 @@ function smarty_function_template_types($params, &$smarty)
 
     $lines[] = "<option value=\"\">{$LANG["phrase_please_select"]}</option>";
 
-    foreach ($template_types as $group_name => $group_section) {
+    foreach ($template_types as $group_name => $group_sections) {
         $lines[] = "<optgroup label=\"$group_name\">";
 
         foreach ($group_sections as $key => $value) {


### PR DESCRIPTION
I found a typo on line 31 in the template_types plugin, which caused the template type dropdown to be empty. Because of this, it was not possible to create new templates.